### PR TITLE
Add weekly S3 backup workflow

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,13 @@
+name: Backup to S3
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"  # weekly, Sunday 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  backup:
+    uses: Specter099/.github/.github/workflows/repo-backup.yml@main
+    secrets: inherit
+    with:
+      s3-bucket: github-repo-backup-1b114b0d7fd4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/backup.yml` — backs up this repo to S3 weekly (Sundays 02:00 UTC) via the reusable `Specter099/.github` backup workflow
- Bucket: `github-repo-backup-1b114b0d7fd4`, role from `AWS_ROLE_ARN` in the `production` environment secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)