### PR TITLE
chore: rename AWS_ROLE_ARN to AWS_BACKUP_ROLE_ARN in backup workflow

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_BACKUP_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Upload to S3


### PR DESCRIPTION
Renames the `AWS_ROLE_ARN` secret reference to `AWS_BACKUP_ROLE_ARN` in the backup workflow for clarity.