### PR TITLE
chore: use AWS_ROLE_ARN instead of AWS_BACKUP_ROLE_ARN

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_BACKUP_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Upload to S3


### PR DESCRIPTION
Switch backup workflow to unified `github-actions-role` via `AWS_ROLE_ARN`. The role now includes `s3:PutObject` on the backup bucket.