### PR TITLE
refactor: remove Route53 alias records from static-site construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Reusable AWS CDK construct for hosting static websites on S3 + CloudFront.
 - S3 buckets for S3 and CloudFront access logs (180-day retention)
 - CloudFront distribution (HTTPS-only, SPA routing, security headers)
 - ACM certificate (imported or DNS-validated via Route53)
-- Route53 A + AAAA records for apex and `www` (optional)
 - CloudWatch alarms: 5xx >5%, 4xx >10%
 - CloudWatch dashboard
 - Optional WAFv2 Web ACL attachment
@@ -64,7 +63,7 @@ app.synth()
 |-----------|------|----------|-------------|
 | `domain_name` | `str` | Yes | Apex domain (e.g. `example.com`) |
 | `dist_path` | `str` | Yes | Absolute path to built frontend `dist/` directory |
-| `hosted_zone_id` | `str` | No* | Route53 hosted zone ID for DNS records + cert validation |
+| `hosted_zone_id` | `str` | No* | Route53 hosted zone ID for cert DNS validation |
 | `certificate_arn` | `str` | No* | ARN of existing ACM certificate to import |
 | `web_acl_id` | `str` | No | WAFv2 Web ACL ARN to attach to CloudFront |
 | `dashboard_name` | `str` | No | CloudWatch dashboard name (defaults to `domain_name`) |

--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -11,7 +11,6 @@ from aws_cdk import (
     aws_certificatemanager as acm,
     aws_cloudwatch as cloudwatch,
     aws_route53 as route53,
-    aws_route53_targets as route53_targets,
 )
 from constructs import Construct
 from cdk_nag import NagSuppressions
@@ -232,40 +231,6 @@ class StaticSiteStack(Stack):
                 ],
             ],
         )
-
-        # Route 53 alias records for apex and www
-        if hosted_zone:
-            cf_target = route53_targets.CloudFrontTarget(distribution)
-
-            route53.ARecord(
-                self,
-                "ApexAlias",
-                zone=hosted_zone,
-                target=route53.RecordTarget.from_alias(cf_target),
-            )
-
-            route53.AaaaRecord(
-                self,
-                "ApexAliasIPv6",
-                zone=hosted_zone,
-                target=route53.RecordTarget.from_alias(cf_target),
-            )
-
-            route53.ARecord(
-                self,
-                "WwwAlias",
-                zone=hosted_zone,
-                record_name="www",
-                target=route53.RecordTarget.from_alias(cf_target),
-            )
-
-            route53.AaaaRecord(
-                self,
-                "WwwAliasIPv6",
-                zone=hosted_zone,
-                record_name="www",
-                target=route53.RecordTarget.from_alias(cf_target),
-            )
 
         # Deploy site assets from dist/
         s3deploy.BucketDeployment(


### PR DESCRIPTION
## Summary

- Removes the 4 Route53 alias records (apex A/AAAA, www A/AAAA) from `StaticSiteStack` — these are now managed in the `route53-cdk` repo
- Removes unused `aws_route53_targets` import
- Updates README to reflect `hosted_zone_id` is for cert DNS validation only (no longer creates DNS records)

## Test plan

- [ ] All 5 existing tests pass (`pytest tests/ -v`)
- [ ] `test_synth_with_hosted_zone` confirms the cert DNS validation path still works with `hosted_zone_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)