### PR TITLE
feat: add exclude_patterns and deployment_memory_limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specter-static-site"
-version = "1.0.0"
+version = "2.1.0"
 description = "Reusable CDK construct for static site hosting on AWS"
 requires-python = ">=3.11"
 dependencies = [

--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -1,4 +1,3 @@
-import aws_cdk as cdk
 from aws_cdk import (
     Stack,
     Duration,
@@ -12,6 +11,7 @@ from aws_cdk import (
     aws_cloudwatch as cloudwatch,
     aws_route53 as route53,
 )
+from typing import List, Optional
 from constructs import Construct
 from cdk_nag import NagSuppressions
 
@@ -28,6 +28,8 @@ class StaticSiteStack(Stack):
         certificate_arn: str | None = None,
         web_acl_id: str | None = None,
         dashboard_name: str | None = None,
+        exclude_patterns: Optional[List[str]] = None,
+        deployment_memory_limit: int = 512,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -199,7 +201,9 @@ class StaticSiteStack(Stack):
                             cloudwatch.Metric(
                                 namespace="AWS/CloudFront",
                                 metric_name="5xxErrorRate",
-                                dimensions_map={"DistributionId": distribution.distribution_id},
+                                dimensions_map={
+                                    "DistributionId": distribution.distribution_id
+                                },
                                 statistic="Average",
                                 period=Duration.minutes(5),
                                 label="5xx Error Rate",
@@ -207,7 +211,9 @@ class StaticSiteStack(Stack):
                             cloudwatch.Metric(
                                 namespace="AWS/CloudFront",
                                 metric_name="4xxErrorRate",
-                                dimensions_map={"DistributionId": distribution.distribution_id},
+                                dimensions_map={
+                                    "DistributionId": distribution.distribution_id
+                                },
                                 statistic="Average",
                                 period=Duration.minutes(5),
                                 label="4xx Error Rate",
@@ -221,7 +227,9 @@ class StaticSiteStack(Stack):
                             cloudwatch.Metric(
                                 namespace="AWS/CloudFront",
                                 metric_name="Requests",
-                                dimensions_map={"DistributionId": distribution.distribution_id},
+                                dimensions_map={
+                                    "DistributionId": distribution.distribution_id
+                                },
                                 statistic="Sum",
                                 period=Duration.minutes(5),
                                 label="Total Requests",
@@ -236,29 +244,49 @@ class StaticSiteStack(Stack):
         s3deploy.BucketDeployment(
             self,
             "DeploySite",
-            sources=[s3deploy.Source.asset(dist_path)],
+            sources=[s3deploy.Source.asset(dist_path, exclude=exclude_patterns or [])],
             destination_bucket=site_bucket,
             distribution=distribution,
             distribution_paths=["/*"],
+            memory_limit=deployment_memory_limit,
         )
 
         # cdk-nag suppressions for accepted deviations
         NagSuppressions.add_resource_suppressions(
             cloudfront_logs_bucket,
-            [{"id": "AwsSolutions-S1", "reason": "CloudFrontLogsBucket is a logging destination; enabling access logs on it would be circular. CloudFront standard logging is disabled due to Free pricing plan incompatibility (HTTP 400)."}],
+            [
+                {
+                    "id": "AwsSolutions-S1",
+                    "reason": "CloudFrontLogsBucket is a logging destination; enabling access logs on it would be circular. CloudFront standard logging is disabled due to Free pricing plan incompatibility (HTTP 400).",
+                }
+            ],
         )
         NagSuppressions.add_resource_suppressions(
             distribution,
-            [{"id": "AwsSolutions-CFR3", "reason": "CloudFront standard logging is incompatible with the Free pricing plan (returns HTTP 400). S3 access logging is active at the bucket layer via S3AccessLogsBucket."}],
+            [
+                {
+                    "id": "AwsSolutions-CFR3",
+                    "reason": "CloudFront standard logging is incompatible with the Free pricing plan (returns HTTP 400). S3 access logging is active at the bucket layer via S3AccessLogsBucket.",
+                }
+            ],
         )
         # BucketDeployment creates a singleton Custom Resource Lambda at the stack level
         # (not under the deploy construct), so these must be suppressed at the stack level.
         NagSuppressions.add_stack_suppressions(
             self,
             [
-                {"id": "AwsSolutions-IAM4", "reason": "CDK BucketDeployment L2 construct attaches AWSLambdaBasicExecutionRole to its internal singleton Lambda service role; not configurable without replacing the construct."},
-                {"id": "AwsSolutions-IAM5", "reason": "CDK BucketDeployment L2 construct requires wildcard S3 permissions on its internal Lambda role to deploy assets; not configurable without replacing the construct."},
-                {"id": "AwsSolutions-L1", "reason": "CDK BucketDeployment L2 construct manages its own internal Lambda runtime version; not configurable without replacing the construct."},
+                {
+                    "id": "AwsSolutions-IAM4",
+                    "reason": "CDK BucketDeployment L2 construct attaches AWSLambdaBasicExecutionRole to its internal singleton Lambda service role; not configurable without replacing the construct.",
+                },
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": "CDK BucketDeployment L2 construct requires wildcard S3 permissions on its internal Lambda role to deploy assets; not configurable without replacing the construct.",
+                },
+                {
+                    "id": "AwsSolutions-L1",
+                    "reason": "CDK BucketDeployment L2 construct manages its own internal Lambda runtime version; not configurable without replacing the construct.",
+                },
             ],
         )
 

--- a/tests/test_static_site_stack.py
+++ b/tests/test_static_site_stack.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 import aws_cdk as cdk
 import pytest
 from specter_static_site import StaticSiteStack
@@ -14,7 +12,7 @@ def make_dist(tmp_path):
 def test_synth_with_certificate_arn(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()
-    stack = StaticSiteStack(
+    StaticSiteStack(
         app,
         "TestStack",
         domain_name="example.com",
@@ -28,7 +26,7 @@ def test_synth_with_certificate_arn(tmp_path):
 def test_synth_with_hosted_zone(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()
-    stack = StaticSiteStack(
+    StaticSiteStack(
         app,
         "TestStack",
         domain_name="example.com",
@@ -43,7 +41,7 @@ def test_synth_with_hosted_zone(tmp_path):
 def test_synth_with_web_acl(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()
-    stack = StaticSiteStack(
+    StaticSiteStack(
         app,
         "TestStack",
         domain_name="example.com",
@@ -58,7 +56,7 @@ def test_synth_with_web_acl(tmp_path):
 def test_synth_with_dashboard_name(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()
-    stack = StaticSiteStack(
+    StaticSiteStack(
         app,
         "TestStack",
         domain_name="example.com",


### PR DESCRIPTION
## Summary
- Add `exclude_patterns: Optional[List[str]]` — passed to `BucketDeployment` source asset exclude, allowing callers to skip large directories (e.g. `uploads/**`) that would OOM the Lambda
- Add `deployment_memory_limit: int = 512` — raises the default from CDK's 128 MB to 512 MB, appropriate for typical static sites
- Fix unused imports/variables in tests (ruff pre-commit hook)

## Test plan
- [ ] Existing tests pass with new defaults
- [ ] `exclude_patterns=["uploads/**"]` excludes directory from zip asset
- [ ] `deployment_memory_limit` is wired through to the Lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)