### PR TITLE
feat: explicit S3 bucket naming convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specter-static-site"
-version = "2.1.0"
+version = "2.2.0"
 description = "Reusable CDK construct for static site hosting on AWS"
 requires-python = ">=3.11"
 dependencies = [

--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -43,10 +43,14 @@ class StaticSiteStack(Stack):
         # Replace dots so domain names work as the default (e.g. "example.com" → "example-com").
         resolved_dashboard_name = (dashboard_name or domain_name).replace(".", "-")
 
+        # Sanitize domain name for use in bucket names (replace dots with hyphens).
+        domain_slug = domain_name.replace(".", "-")
+
         # S3 access logs bucket
         s3_access_logs_bucket = s3.Bucket(
             self,
             "S3AccessLogsBucket",
+            bucket_name=f"{domain_slug}-s3-logs-{self.account}-{self.region}-an",
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             encryption=s3.BucketEncryption.S3_MANAGED,
             enforce_ssl=True,
@@ -63,6 +67,7 @@ class StaticSiteStack(Stack):
         cloudfront_logs_bucket = s3.Bucket(
             self,
             "CloudFrontLogsBucket",
+            bucket_name=f"{domain_slug}-cf-logs-{self.account}-{self.region}-an",
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             encryption=s3.BucketEncryption.KMS_MANAGED,
             enforce_ssl=True,
@@ -80,6 +85,7 @@ class StaticSiteStack(Stack):
         site_bucket = s3.Bucket(
             self,
             "SiteBucket",
+            bucket_name=f"{domain_slug}-site-{self.account}-{self.region}-an",
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             encryption=s3.BucketEncryption.S3_MANAGED,
             enforce_ssl=True,


### PR DESCRIPTION
## Summary
- Adds explicit `bucket_name` to all three S3 buckets using the `{purpose}-{account}-{region}-an` pattern
- Sanitizes domain name (dots → hyphens) for use in bucket names
- Bumps version to `2.2.0`

## Bucket names produced
- `{domain}-site-{account}-{region}-an`
- `{domain}-cf-logs-{account}-{region}-an`
- `{domain}-s3-logs-{account}-{region}-an`

🤖 Generated with [Claude Code](https://claude.com/claude-code)