### PR TITLE
feat: set BucketNamespace=account-regional for -an buckets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specter-static-site"
-version = "2.2.0"
+version = "2.3.0"
 description = "Reusable CDK construct for static site hosting on AWS"
 requires-python = ">=3.11"
 dependencies = [

--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -62,6 +62,9 @@ class StaticSiteStack(Stack):
                 ),
             ],
         )
+        s3_access_logs_bucket.node.default_child.add_property_override(
+            "BucketNamespace", "account-regional"
+        )
 
         # CloudFront access logs bucket
         cloudfront_logs_bucket = s3.Bucket(
@@ -79,6 +82,9 @@ class StaticSiteStack(Stack):
                     expiration=Duration.days(180),
                 ),
             ],
+        )
+        cloudfront_logs_bucket.node.default_child.add_property_override(
+            "BucketNamespace", "account-regional"
         )
 
         # S3 bucket for site assets
@@ -99,6 +105,9 @@ class StaticSiteStack(Stack):
                     noncurrent_version_expiration=Duration.days(30),
                 )
             ],
+        )
+        site_bucket.node.default_child.add_property_override(
+            "BucketNamespace", "account-regional"
         )
 
         # Look up Route 53 hosted zone if provided


### PR DESCRIPTION
## Summary
- Adds `BucketNamespace: account-regional` via CDK escape hatch on all three S3 buckets
- Required by AWS when bucket names end in `-an` (account-regional namespace convention)
- Bumps version to `2.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)