### PR TITLE
fix: pass exclude patterns to BucketDeployment to prevent pruning uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specter-static-site"
-version = "2.3.0"
+version = "2.4.0"
 description = "Reusable CDK construct for static site hosting on AWS"
 requires-python = ">=3.11"
 dependencies = [

--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -264,6 +264,7 @@ class StaticSiteStack(Stack):
             distribution=distribution,
             distribution_paths=["/*"],
             memory_limit=deployment_memory_limit,
+            exclude=exclude_patterns or [],
         )
 
         # cdk-nag suppressions for accepted deviations


### PR DESCRIPTION
## Summary
- Passes `exclude=exclude_patterns or []` to the `BucketDeployment` constructor, not just to `Source.asset()`
- Without this, `BucketDeployment`'s default `prune=True` runs `aws s3 sync --delete` on every CDK deploy, wiping any S3 paths (e.g. `uploads/`) that aren't in the `dist/` bundle
- Bumps version to 2.4.0

## Test Plan
- [ ] Deploy site with `exclude_patterns=["uploads/**"]` configured — verify existing `/uploads/` objects survive the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)