### PR TITLE
feat: add deploy_role_arns parameter for CI/CD bucket access

### DIFF
--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -9,6 +9,7 @@ from aws_cdk import (
     aws_s3_deployment as s3deploy,
     aws_certificatemanager as acm,
     aws_cloudwatch as cloudwatch,
+    aws_iam as iam,
     aws_route53 as route53,
 )
 from typing import List, Optional
@@ -17,7 +18,7 @@ from cdk_nag import NagSuppressions
 
 
 class StaticSiteStack(Stack):
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         scope: Construct,
         construct_id: str,
@@ -28,6 +29,7 @@ class StaticSiteStack(Stack):
         certificate_arn: str | None = None,
         web_acl_id: str | None = None,
         dashboard_name: str | None = None,
+        deploy_role_arns: Optional[List[str]] = None,
         exclude_patterns: Optional[List[str]] = None,
         deployment_memory_limit: int = 512,
         **kwargs,
@@ -109,6 +111,15 @@ class StaticSiteStack(Stack):
         site_bucket.node.default_child.add_property_override(
             "BucketNamespace", "account-regional"
         )
+
+        # Grant external roles read/write access to the site bucket (e.g. CI/CD pipelines).
+        for role_arn in deploy_role_arns or []:
+            role = iam.Role.from_role_arn(
+                self,
+                f"DeployRole{role_arn.split('/')[-1]}",
+                role_arn,
+            )
+            site_bucket.grant_read_write(role)
 
         # Look up Route 53 hosted zone if provided
         hosted_zone = None

--- a/tests/test_static_site_stack.py
+++ b/tests/test_static_site_stack.py
@@ -68,6 +68,21 @@ def test_synth_with_dashboard_name(tmp_path):
     assert assembly is not None
 
 
+def test_synth_with_deploy_role_arns(tmp_path):
+    dist = make_dist(tmp_path)
+    app = cdk.App()
+    StaticSiteStack(
+        app,
+        "TestStack",
+        domain_name="example.com",
+        dist_path=dist,
+        certificate_arn="arn:aws:acm:us-east-1:123456789012:certificate/test-cert",
+        deploy_role_arns=["arn:aws:iam::123456789012:role/github-actions-role"],
+    )
+    assembly = app.synth()
+    assert assembly is not None
+
+
 def test_raises_without_cert_or_zone(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()


### PR DESCRIPTION
## Summary
Add optional `deploy_role_arns` parameter to `StaticSiteStack`. Each ARN gets `grant_read_write` on the site bucket, allowing CI/CD pipelines to sync content directly to S3.

## Motivation
The repo-health-dashboard workflow deploys content via `aws s3 sync` using the `github-actions-role`. Without this, the bucket policy had to be manually managed outside CDK, which gets overwritten on every `cdk deploy`.

## Usage
```python
StaticSiteStack(
    app, "MySite",
    domain_name="example.com",
    dist_path="dist",
    certificate_arn="arn:aws:acm:...",
    deploy_role_arns=["arn:aws:iam::123456789012:role/github-actions-role"],
)
```

## Test plan
- [x] Existing tests pass (5/5)
- [x] New test `test_synth_with_deploy_role_arns` passes
- [ ] After merge, update `repo-health-dashboard/app.py` to pass the role ARN
- [ ] Redeploy stack and verify workflow deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)