### PR TITLE
fix: hardcode pip packages in Lambda bundling command

### DIFF
--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -202,7 +202,7 @@ class StaticSiteStack(Stack):
                         command=[
                             "bash",
                             "-c",
-                            "pip install -r requirements.txt -t /asset-output"
+                            "pip install PyJWT cryptography urllib3 -t /asset-output"
                             " && cp *.py /asset-output/"
                             f" && echo '{auth_config}' > /asset-output/config.json",
                         ],


### PR DESCRIPTION
requirements.txt not included in pip-installed package. Hardcode package names directly.