### PR TITLE
feat: add skip_deployment parameter

### DIFF
--- a/specter_static_site/static_site_stack.py
+++ b/specter_static_site/static_site_stack.py
@@ -40,6 +40,7 @@ class StaticSiteStack(Stack):
         cognito_client_id: str | None = None,
         cognito_client_secret: str | None = None,
         cognito_domain: str | None = None,
+        skip_deployment: bool = False,
         exclude_patterns: list[str] | None = None,
         deployment_memory_limit: int = 512,
         **kwargs,
@@ -342,17 +343,20 @@ class StaticSiteStack(Stack):
             ],
         )
 
-        # Deploy site assets from dist/
-        s3deploy.BucketDeployment(
-            self,
-            "DeploySite",
-            sources=[s3deploy.Source.asset(dist_path, exclude=exclude_patterns or [])],
-            destination_bucket=site_bucket,
-            distribution=distribution,
-            distribution_paths=["/*"],
-            memory_limit=deployment_memory_limit,
-            exclude=exclude_patterns or [],
-        )
+        # Deploy site assets from dist/ (skip when CI/CD handles deployment separately).
+        if not skip_deployment:
+            s3deploy.BucketDeployment(
+                self,
+                "DeploySite",
+                sources=[
+                    s3deploy.Source.asset(dist_path, exclude=exclude_patterns or [])
+                ],
+                destination_bucket=site_bucket,
+                distribution=distribution,
+                distribution_paths=["/*"],
+                memory_limit=deployment_memory_limit,
+                exclude=exclude_patterns or [],
+            )
 
         # cdk-nag suppressions for accepted deviations
         NagSuppressions.add_resource_suppressions(

--- a/tests/test_static_site_stack.py
+++ b/tests/test_static_site_stack.py
@@ -101,6 +101,21 @@ def test_synth_with_cognito_auth(tmp_path):
     assert assembly is not None
 
 
+def test_synth_with_skip_deployment(tmp_path):
+    dist = make_dist(tmp_path)
+    app = cdk.App()
+    StaticSiteStack(
+        app,
+        "TestStack",
+        domain_name="example.com",
+        dist_path=dist,
+        certificate_arn="arn:aws:acm:us-east-1:123456789012:certificate/test-cert",
+        skip_deployment=True,
+    )
+    assembly = app.synth()
+    assert assembly is not None
+
+
 def test_partial_cognito_params_raises(tmp_path):
     dist = make_dist(tmp_path)
     app = cdk.App()


### PR DESCRIPTION
Skip BucketDeployment when CI/CD handles S3 sync separately. Prevents cdk deploy from overwriting workflow-deployed content.