### PR TITLE
fix: add gitleaks as separate job in pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,3 +8,6 @@ jobs:
   review:
     uses: Specter099/.github/.github/workflows/cdk-review.yml@main
     secrets: inherit
+
+  gitleaks:
+    uses: Specter099/.github/.github/workflows/gitleaks.yml@main


### PR DESCRIPTION
## Summary
- Adds `gitleaks` as a direct job in `pr.yml` instead of relying on it being nested inside `cdk-review.yml`
- Fixes the `startup_failure` on every PR since March 22 — caused by GitHub's one-level nesting limit on reusable workflows
- Companion to Specter099/.github#24 which removes the nested gitleaks call from `cdk-review.yml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)