### PR TITLE
fix: run security scan on PR only, not push to main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,6 @@
 name: Security — Access Analyzer
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Removes the `push: [main]` trigger from `security.yml`. Per the Specter099 CI/CD trigger convention ([`Specter099/.github` CLAUDE.md](https://github.com/Specter099/.github/blob/main/CLAUDE.md)):

- All checks (security scans, tests, synth/diff) run on `pull_request: [main]`.
- `push: [main]` is reserved for deploys.

Today, `security.yml` fires on both — which re-runs the same Access Analyzer scan at merge time on code that already passed the same check on the PR.

## Test plan

- [ ] Open/push a test PR and confirm the Access Analyzer job runs
- [ ] Merge and confirm no redundant Access Analyzer run fires on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)