### PR TITLE
fix: restore secrets: inherit for weekly S3 backup

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -5,12 +5,14 @@ on:
   workflow_dispatch:
 jobs:
   backup:
-    # Pinned to a commit SHA (mutable-ref supply-chain hardening). No secrets
-    # are passed: the reusable workflow reads AWS_ROLE_ARN from this repo's
-    # "backup" GitHub Environment.
-    uses: Specter099/.github/.github/workflows/repo-backup.yml@2633bc5b281230a26aefdd42ee9e6243b0a7ad1f # main 2026-07-09
+    # Pinned to a commit SHA (mutable-ref supply-chain hardening). The
+    # reusable workflow's `environment:` binding only scopes which
+    # environment's secrets apply once inside that job - it does not pull
+    # secrets from the caller, so AWS_ROLE_ARN must be passed explicitly.
+    uses: Specter099/.github/.github/workflows/repo-backup.yml@2633bc5b281230a26aefdd42ee9e6243b0a7ad1f  # main 2026-07-09
     with:
       s3-bucket: github-repo-backup-1b114b0d7fd4
+    secrets: inherit
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- Weekly backup runs have been failing with "Credentials could not be loaded ... Could not load credentials from any providers".
- Root cause: same pattern as ssmtree#51 — `secrets: inherit` was dropped when calling `Specter099/.github/.github/workflows/repo-backup.yml`, on the belief that the reusable workflow's `environment:` binding alone would resolve `AWS_ROLE_ARN`. It does not — reusable workflows only receive secrets explicitly passed or inherited from the caller.
- Restores `secrets: inherit`, corrects the comment, and fixes a pre-existing yamllint comment-spacing warning on the same line.

## Test plan
- [ ] `yamllint` passes (verified locally)
- [ ] Trigger `workflow_dispatch` on this branch (or after merge) and confirm the backup run succeeds and an object lands in the S3 bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)